### PR TITLE
Limit bad-include/import-yang-version setting

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -150,13 +150,13 @@ For instance; the name contains any invalid characters, or equals to any YANG bu
 
 Issues code when there is an inconsistency between a module's version and the version of the included modules.
 
- (default severity: error)
+ (fixed severity: error)
 
 #### `bad-import-yang-version`
 
 Issues code when there is an inconsistency between a module's version and the version of the included modules.
 
- (default severity: error)
+ (fixed severity: error)
 
 #### `duplicate-enumerable-name`
 

--- a/schema/yang-lsp-settings-schema.json
+++ b/schema/yang-lsp-settings-schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/TypeFox/yang-lsp/schema/yang-lsp-settings-schema.json",
+  "$id": "https://github.com/TypeFox/yang-lsp/blob/master/schema/yang-lsp-settings-schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "YANG LSP Settings JSON Schema",
   "description": "JSON Schema for YANG LSP settings file 'yang.settings'.\nSee https://github.com/TypeFox/yang-lsp/blob/master/docs/Settings.md",
@@ -53,6 +53,11 @@
             "error",
             "warning",
             "ignore"
+          ]
+        },
+        "fixed-severity": {
+          "enum": [
+            "error"
           ]
         }
       },
@@ -124,12 +129,12 @@
         },
         "bad-include-yang-version": {
           "description": "Issues code when there is an inconsistency between a module's yang-version and the yang-version of the included modules.",
-          "$ref": "#/properties/diagnostic/$defs/severity",
+          "$ref": "#/properties/diagnostic/$defs/fixed-severity",
           "default": "error"
         },
         "bad-import-yang-version": {
           "description": "Issues code when there is an inconsistency between a module's yang-version and the yang-version of the imported modules.",
-          "$ref": "#/properties/diagnostic/$defs/severity",
+          "$ref": "#/properties/diagnostic/$defs/fixed-severity",
           "default": "error"
         },
         "duplicate-enumerable-name": {


### PR DESCRIPTION
Based on discussion in TypeFox/yang-vscode#40 bad-include-yang-version and bad-import-yang-version are not configurable.

Updates the schema introduced in context of TypeFox/yang-lsp#233

Also updated Settings.md documentation to clarify.