### PR TITLE
Fix bad-import-yang-version handling

### DIFF
--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
@@ -40,6 +40,7 @@ import io.typefox.yang.yang.Pattern
 import io.typefox.yang.yang.Presence
 import io.typefox.yang.yang.Refinable
 import io.typefox.yang.yang.Revision
+import io.typefox.yang.yang.RevisionDate
 import io.typefox.yang.yang.Rpc
 import io.typefox.yang.yang.SchemaNode
 import io.typefox.yang.yang.SchemaNodeIdentifier
@@ -143,8 +144,9 @@ class YangValidator extends AbstractYangValidator {
 				.filter[module?.eResource !== null && !module.eIsProxy]
 				.forEach [ importStatement |
 					val importedModuleVersion = importStatement.module.yangVersion
-					if(baseModuleVersion != importedModuleVersion) {
-						val message = '''Cannot import a version «importedModuleVersion» module in a version «baseModuleVersion» module.''';
+					val revisionDate = importStatement.substatementsOfType(RevisionDate)
+					if (!revisionDate.nullOrEmpty && baseModuleVersion != importedModuleVersion) {
+						val message = '''Cannot import a version «importedModuleVersion» module by revision in a version «baseModuleVersion» module.''';
 						error(message, importStatement, ABSTRACT_IMPORT__MODULE, BAD_IMPORT_YANG_VERSION);
 					}
 				];

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/validation/ImportVersionConstraintTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/validation/ImportVersionConstraintTest.xtend
@@ -68,20 +68,50 @@ class ImportVersionConstraintTest extends AbstractYangTest {
 			    yang-version 1;
 			    namespace urn:ietf:params:xml:ns:yang:foo;
 			    prefix foo;
-			
+
 			    import bar {
-			    		prefix bar;
-			    	}
+			        prefix bar;
+			        revision-date 1970-01-01;
+			    }
 			}
 		''')
 		load('''
 			module bar {
 			    yang-version 1.1;
-				namespace urn:ietf:params:xml:ns:yang:bar;
-				prefix bar;
+			    namespace urn:ietf:params:xml:ns:yang:bar;
+			    prefix bar;
+			    revision 1970-01-01 {
+			        reference "";
+			    }
 			}
 		''')
 		validator.validate(foo.root.eResource)
 		assertError(foo.root.substatements.filter(Import).head, BAD_IMPORT_YANG_VERSION)
+	}
+
+	@Test def void testImportVersion_1() {
+		val foo = load('''
+			module foo {
+			    yang-version 1;
+			    namespace urn:ietf:params:xml:ns:yang:foo;
+			    prefix foo;
+
+			    import bar {
+			        prefix bar;
+			    }
+			}
+		''')
+		load('''
+			module bar {
+			    yang-version 1.1;
+			    namespace urn:ietf:params:xml:ns:yang:bar;
+			    prefix bar;
+			    revision 1970-01-01 {
+			        reference "";
+			    }
+			}
+		''')
+		validator.validate(foo.root.eResource)
+		assertNoError(foo.root.substatements.filter(Import).head, BAD_IMPORT_YANG_VERSION)
 	}
 }


### PR DESCRIPTION
It is allowed to import YANG 1.1 modules from YANG 1.0 when importing without revision-date. bad-import-yang-version was flagged even when a YANG 1.1 module was imported by YANG 1.0 module without specifying revision-date and is now fixed.

This fix addresses TypeFox/yang-lsp#228