### PR TITLE
Fix bad-import-yang-version handling

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Gradle Build",
+      "type": "shell",
+      "command": "cd yang-lsp && ./gradlew build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # yang-lsp
+
 [![GH Build Status](https://github.com/theia-ide/yang-lsp/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/theia-ide/yang-lsp/actions/workflows/main.yml)
 [![Build status](https://ci.appveyor.com/api/projects/status/96eo9k5yo0wtpj50/branch/master?svg=true)](https://ci.appveyor.com/project/kittaakos/yang-lsp/branch/master)
 
@@ -8,34 +9,34 @@ A language server for YANG (see [Language Server Protocol](https://github.com/Mi
 
 The language server application is available in two distributions:
 
- - `yang-language-server_<version>.zip` (plain language server)
- - `yang-language-server_diagram-extension_<version>.zip` (language server with diagram extension for [sprotty](https://github.com/theia-ide/sprotty))
+- `yang-language-server_<version>.zip` (plain language server)
+- `yang-language-server_diagram-extension_<version>.zip` (language server with diagram extension for [sprotty](https://github.com/theia-ide/sprotty))
 
 Both variants include start scripts to launch the background process. Connect its input/output streams to your host application in order to communicate with the language server.
 
 The YANG Language Server is currently being used in
- - [YANGSTER](https://github.com/theia-ide/yangster) based on [Theia](https://github.com/theia-ide/theia) (incl. diagram extension)
- - [Yang VS Code](https://github.com/theia-ide/yang-vscode) available on the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=typefox.yang-vscode)
- - [Yang Eclipse](https://github.com/theia-ide/yang-eclipse)
+
+- [YANGSTER](https://github.com/theia-ide/yangster) based on [Theia](https://github.com/theia-ide/theia) (incl. diagram extension)
+- [Yang VS Code](https://github.com/theia-ide/yang-vscode) available on the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=typefox.yang-vscode)
+- [Yang Eclipse](https://github.com/theia-ide/yang-eclipse)
 
 ## Build
 
-    git clone https://github.com/theia-ide/yang-lsp.git \
-    && cd yang-lsp/yang-lsp \
-    && ./gradlew build
+```shell
+  git clone https://github.com/theia-ide/yang-lsp.git
+  cd yang-lsp/yang-lsp
+  ./gradlew build
+```
 
+## Release Engineering
 
-# Release Engineering
-
-The yang-lsp is the base of multiple binaries 
-
+The yang-lsp is the base of multiple binaries
 
 | Repository | Client | Binary | Bin Repo | CI  | Trigger |
 | ---------- | ------ | ------ | -------- | --- | ---------- |
-| [yang-lsp](https://github.com/theia-ide/yangs-lsp) | LSP           | JAR + script | GH Action Artifacts | [GH Action](https://github.com/theia-ide/yang-lsp/actions/workflows/main.yml) | GH Commit / PR | 
-| [yangster](https://github.com/theia-ide/yangster)  | Theia Browser | Docker image | Docker Hub | [Docker Hub](https://hub.docker.com/r/typefox/yangster/builds) | GitHub hook / Jenkins pipeline| 
-|                                                    | Theia          | Theia extension| npm |  [Jenkins](http://services.typefox.io/open-source/jenkins/job/yangster/) | `yarn run publish` | 
+| [yang-lsp](https://github.com/theia-ide/yangs-lsp) | LSP           | JAR + script | GH Action Artifacts | [GH Action](https://github.com/theia-ide/yang-lsp/actions/workflows/main.yml) | GH Commit / PR |
+| [yangster](https://github.com/theia-ide/yangster)  | Theia Browser | Docker image | Docker Hub | [Docker Hub](https://hub.docker.com/r/typefox/yangster/builds) | GitHub hook / Jenkins pipeline|
+|                                                    | Theia          | Theia extension| npm |  [Jenkins](http://services.typefox.io/open-source/jenkins/job/yangster/) | `yarn run publish` |
 | [yangster-electron](https://github.com/theia-ide/yangster-electron) | Theia Electron | executables | ? | ? | ? |
 | [yang-eclipse](https://github.com/theia-ide/yang-eclipse) | Eclipse | p2 update site | Eclipse Marketplace | [Jenkins](http://services.typefox.io/open-source/jenkins/job/yang-eclipse/) | GitHub hook / Jenkins pipeline |
 | [yang-vscode](https://github.com/theia-ide/yang-vscode) | VSCode | VSCode extension | VSCode Marketplace | - | `vsce` |
-

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
@@ -138,14 +138,14 @@ class YangValidator extends AbstractYangValidator {
 				}
 			];
 
-		// A YANG version 1 module or submodule must not import a YANG version 1.1 module by revision.	
+		// A YANG version 1 module or submodule must not import a YANG version 1.1 module by revision.
 		if (baseModuleVersion == YANG_1) {
 			baseModule.substatementsOfType(Import)
 				.filter[module?.eResource !== null && !module.eIsProxy]
 				.forEach [ importStatement |
 					val importedModuleVersion = importStatement.module.yangVersion
 					val revisionDate = importStatement.substatementsOfType(RevisionDate)
-					if (!revisionDate.nullOrEmpty && baseModuleVersion != importedModuleVersion) {
+					if (baseModuleVersion != importedModuleVersion && !revisionDate.empty) {
 						val message = '''Cannot import a version «importedModuleVersion» module by revision in a version «baseModuleVersion» module.''';
 						error(message, importStatement, ABSTRACT_IMPORT__MODULE, BAD_IMPORT_YANG_VERSION);
 					}

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
@@ -40,6 +40,7 @@ import io.typefox.yang.yang.Pattern
 import io.typefox.yang.yang.Presence
 import io.typefox.yang.yang.Refinable
 import io.typefox.yang.yang.Revision
+import io.typefox.yang.yang.RevisionDate
 import io.typefox.yang.yang.Rpc
 import io.typefox.yang.yang.SchemaNode
 import io.typefox.yang.yang.SchemaNodeIdentifier
@@ -143,8 +144,9 @@ class YangValidator extends AbstractYangValidator {
 				.filter[module?.eResource !== null && !module.eIsProxy]
 				.forEach [ importStatement |
 					val importedModuleVersion = importStatement.module.yangVersion
-					if(baseModuleVersion != importedModuleVersion) {
-						val message = '''Cannot import a version «importedModuleVersion» module in a version «baseModuleVersion» module.''';
+					val revisionDate = importStatement.substatementsOfType(RevisionDate)
+					if (!revisionDate.nullOrEmpty && baseModuleVersion != importedModuleVersion) {
+						val message = '''Cannot import a version «importedModuleVersion» module by revision in a version «baseModuleVersion» module.''';
 						error(message, importStatement, ABSTRACT_IMPORT__MODULE, BAD_IMPORT_YANG_VERSION);
 					}
 				];

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/validation/ImportVersionConstraintTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/validation/ImportVersionConstraintTest.xtend
@@ -68,20 +68,50 @@ class ImportVersionConstraintTest extends AbstractYangTest {
 			    yang-version 1;
 			    namespace urn:ietf:params:xml:ns:yang:foo;
 			    prefix foo;
-			
+
 			    import bar {
-			    		prefix bar;
-			    	}
+			        prefix bar;
+			        revision-date 1970-01-01;
+			    }
 			}
 		''')
 		load('''
 			module bar {
 			    yang-version 1.1;
-				namespace urn:ietf:params:xml:ns:yang:bar;
-				prefix bar;
+			    namespace urn:ietf:params:xml:ns:yang:bar;
+			    prefix bar;
+			    revision 1970-01-01 {
+			        reference "";
+			    }
 			}
 		''')
 		validator.validate(foo.root.eResource)
 		assertError(foo.root.substatements.filter(Import).head, BAD_IMPORT_YANG_VERSION)
+	}
+
+	@Test def void testImportVersion_1() {
+		val foo = load('''
+			module foo {
+			    yang-version 1;
+			    namespace urn:ietf:params:xml:ns:yang:foo;
+			    prefix foo;
+
+			    import bar {
+			        prefix bar;
+			    }
+			}
+		''')
+		load('''
+			module bar {
+			    yang-version 1.1;
+			    namespace urn:ietf:params:xml:ns:yang:bar;
+			    prefix bar;
+			    revision 1970-01-01 {
+			        reference "";
+			    }
+			}
+		''')
+		validator.validate(foo.root.eResource)
+		assertNoErrors(foo.root.substatements.filter(Import).head, BAD_IMPORT_YANG_VERSION)
 	}
 }


### PR DESCRIPTION
It is allowed to import YANG 1.1 modules from YANG 1.0 when importing without revision-date. bad-import-yang-version was flagged even when a YANG 1.1 module was imported by YANG 1.0 module without specifying revision-date and is now fixed.

This fix addresses TypeFox/yang-lsp#228